### PR TITLE
Adds old value to changed.fu.spinbox event

### DIFF
--- a/js/spinbox.js
+++ b/js/spinbox.js
@@ -188,12 +188,13 @@
 		},
 
 		triggerChangedEvent: function triggerChangedEvent() {
+			var last = this.lastValue;
 			var currentValue = this.getValue();
 			if (currentValue === this.lastValue) return;
 			this.lastValue = currentValue;
 
 			// Primary changed event
-			this.$element.trigger('changed.fu.spinbox', currentValue);
+			this.$element.trigger('changed.fu.spinbox', { oldValue: last, newValue: currentValue });
 		},
 
 		startSpin: function startSpin(type) {


### PR DESCRIPTION
I modified the "changed.fu.spinbox" event to include both current and old values. In my particular scenario I need that to know if the change was an increment or decrement and based on that I can perform a specific action.

I know this is a breaking change because the event would now send an object instead of a plain value, but I found no other solutions than this to comply with my requirements
